### PR TITLE
Add support for injected languages

### DIFF
--- a/lua/nvim-treesitter-endwise.lua
+++ b/lua/nvim-treesitter-endwise.lua
@@ -1,5 +1,3 @@
-local queries = require("nvim-treesitter.query")
-
 local M = {}
 
 function M.init()
@@ -8,9 +6,6 @@ function M.init()
             module_path = 'nvim-treesitter.endwise',
             enable = false,
             disable = {},
-            is_supported = function(lang)
-                return queries.has_query_files(lang, 'endwise')
-            end,
         }
     }
 end

--- a/lua/nvim-treesitter/endwise.lua
+++ b/lua/nvim-treesitter/endwise.lua
@@ -76,11 +76,22 @@ local function endwise(bufnr)
     col = col - 1
 
     local root_lang_tree = parsers.get_parser(bufnr)
-    local root = ts_utils.get_root_for_position(row, col, root_lang_tree)
+    local tree_at_pos = root_lang_tree:language_for_range({row, col, row, col})
+    lang = tree_at_pos:lang();
+    if not lang then
+        return
+    end
+
+    local root = ts_utils.get_root_for_position(row, col, tree_at_pos)
     if not root then
         return
     end
+
     local query = queries.get_query(lang, 'endwise')
+    if not query then
+        return
+    end
+
     local range = {root:range()}
 
     for _, match, metadata in query:iter_matches(root, bufnr, range[1], range[3] + 1) do


### PR DESCRIPTION
I'd like this plugin to work for languages nested in other language files, like Lua in Vimscript.

Unfortunately we wouldn't be able to use `queries.has_query_files` to check if the file is supported because a supported language could be injected in a language that isn't supported. I've just removed the `is_supported` configuration to make it work. However, his has the downside that this plugin will run for all buffers, even if they aren't supported. I don't know if there is an easy way to check if a language is injected. If not, maybe this could be opt-in with a config key?

What are your thoughts?