### PR TITLE
Prevent indenting case statements and handle conditionless cases

### DIFF
--- a/queries/ruby/endwise.scm
+++ b/queries/ruby/endwise.scm
@@ -9,7 +9,8 @@
 ((if condition: (_) @cursor) @endable @indent (#endwise! "end"))
 ((begin "begin" @cursor . (rescue "rescue" @cursor exceptions: (_)? @cursor)? . (ensure "ensure" @cursor)?) @endable @indent (#endwise! "end"))
 ((unless condition: (_) @cursor) @endable @indent (#endwise! "end"))
-((case value: (_) @cursor) @endable @indent (#endwise! "end"))
+((case value: (_) @cursor) @endable @indent (#endwise! "end" nil "end" 0))
+(((case) @cursor) @endable @indent (#endwise! "end" nil "end" 0))
 
 ((ERROR ("module" @indent . [(constant) (scope_resolution)] @cursor)) (#endwise! "end"))
 ((ERROR ("class" @indent . [(constant) (scope_resolution)] @cursor . (superclass)? @cursor)) (#endwise! "end"))

--- a/tests/endwise/ruby.rb
+++ b/tests/endwise/ruby.rb
@@ -404,7 +404,7 @@ test "ruby, nested case stmt", <<~END
 +case foo
 +when 0
 +  case bar
-+
++  
 +  end
 +end
 END

--- a/tests/endwise/ruby.rb
+++ b/tests/endwise/ruby.rb
@@ -392,7 +392,7 @@ END
 test "ruby, case stmt", <<~END
 -case foo█
 +case foo
-+  
++
 +end
 END
 
@@ -404,7 +404,7 @@ test "ruby, nested case stmt", <<~END
 +case foo
 +when 0
 +  case bar
-+    
++
 +  end
 +end
 END

--- a/tests/endwise/ruby.rb
+++ b/tests/endwise/ruby.rb
@@ -451,3 +451,10 @@ test "ruby, this will fail", <<~END
 +
 +FOO
 END
+
+test "ruby, conditionless case stmt", <<~END
+-case█
++case
++
++end
+END


### PR DESCRIPTION
1. Handles case statements without a condition. Ex:
```ruby
case
when foo.zero?
  bar
end
```

2. Stops case statements from indenting after pressing enter. `when` shouldn't be indented. 