### PR TITLE
support vim augroups

### DIFF
--- a/queries/vim/endwise.scm
+++ b/queries/vim/endwise.scm
@@ -3,6 +3,7 @@
 ((while_loop condition: (_) @cursor) @indent (#endwise! "endwhile"))
 ((function_definition "function" @indent (function_declaration parameters: (_) @cursor) . ["abort" "closure" "dict" "range"]* @cursor) @endable (#endwise! "end" @indent "endfunction"))
 ((try_statement "try" @cursor) @endable @indent (#endwise! "endtry"))
+((augroup_statement (augroup_name) @cursor (#not-match? @cursor "(END|end)")) @indent (#endwise! "augroup END"))
 
 ((ERROR ("if" @indent . (_) @cursor)) (#endwise! "endif"))
 ((ERROR ("for" @indent . (_) . "in" . (_) @cursor)) (#endwise! "endfor"))

--- a/tests/endwise/vim.rb
+++ b/tests/endwise/vim.rb
@@ -173,3 +173,10 @@ test "vim, global function has dynamic end text", <<~END
 +  
 +endfun
 END
+
+test "vim, augroup", <<~END
+-augroup foo█
++augroup foo
++  
++augroup END
+END


### PR DESCRIPTION
This adds `augroup END` after beginning a new `augroup`. It ignores `augroup end` or `augroup END`.

Unfortunately, I can't get the tests working locally.