### PR TITLE
fix: support `Query:iter_matches` changes in upstream neovim

### DIFF
--- a/lua/nvim-treesitter/endwise.lua
+++ b/lua/nvim-treesitter/endwise.lua
@@ -100,6 +100,7 @@ local function add_end_node(indent_node_range, endable_node_range, end_text, shi
     vim.fn.cursor(crow, #cursor_indentation + 1)
 end
 
+local nvim_supports_quantified_captures = vim.version() > vim.version.parse("0.10.0")
 local function endwise(bufnr)
     local lang = parsers.get_buf_lang(bufnr)
     if not lang then
@@ -136,6 +137,9 @@ local function endwise(bufnr)
     for _, match, metadata in query:iter_matches(root, bufnr, range[1], range[3] + 1) do
         local indent_node, cursor_node, endable_node
         for id, node in pairs(match) do
+            if nvim_supports_quantified_captures then
+                node = node[#node]
+            end
             if query.captures[id] == 'indent' then
                 indent_node = node
             elseif query.captures[id] == 'cursor' then


### PR DESCRIPTION
Copied from the body of the commit:

> Neovim's `Query:iter_matches` function now returns a list of Nodes for each match in nightly. Previously the `iter_matches` function only returned the *last* node. To get that previous behavior we just pull the last node out of the returned list of nodes.
> 
> According to `:h news.txt`, `Query:iter_matches` added a backwards compatibility option (`all=false`), but the intent is to remove it in a future release — thus it's better to rip the band-aid off now instead of fighting this again later on.
> 
> See https://github.com/neovim/neovim/commit/6913c5e1d975a11262d08b3339d50b579e6b6bb8.


TL;DR:

Neovim upstream recently changed the return from `Query:iter_matches` and this adds a simple shim to support it for current nightly users. It should have the exact same behavior as what was previously used AFAIK.