### PR TITLE
Adapt to new Neovim defaults in TS query API

### DIFF
--- a/lua/nvim-treesitter/endwise.lua
+++ b/lua/nvim-treesitter/endwise.lua
@@ -6,6 +6,8 @@ local M = {}
 local indent_regex = vim.regex('\\v^\\s*\\zs\\S')
 local tracking = {}
 
+local query_opts = vim.fn.has "nvim-0.10" == 1 and { force = true, all = false } or true
+
 local function tabstr()
     if vim.bo.expandtab then
         return string.rep(" ", vim.fn.shiftwidth())
@@ -133,7 +135,7 @@ local function endwise(bufnr)
 
     local range = { root:range() }
 
-    for _, match, metadata in query:iter_matches(root, bufnr, range[1], range[3] + 1) do
+    for _, match, metadata in query:iter_matches(root, bufnr, range[1], range[3] + 1, query_opts) do
         local indent_node, cursor_node, endable_node
         for id, node in pairs(match) do
             if query.captures[id] == 'indent' then
@@ -187,7 +189,7 @@ vim.treesitter.query.add_directive('endwise!', function(match, _, _, predicate, 
     metadata.endwise_end_node_type = predicate[4]
     metadata.endwise_shiftcount = predicate[5] or 1
     metadata.endwise_end_suffix_pattern = predicate[6] or '^.*$'
-end)
+end, query_opts)
 
 vim.on_key(function(key)
     if key ~= "\r" then return end


### PR DESCRIPTION
Fixes #41.

Adapted from a similar fix for nvim-treesitter:
https://github.com/nvim-treesitter/nvim-treesitter/pull/7114