### PR TITLE
Add support for Verilog (SystemVerilog)

### DIFF
--- a/queries/verilog/endwise.scm
+++ b/queries/verilog/endwise.scm
@@ -1,0 +1,71 @@
+((module_declaration
+   . [(module_nonansi_header ";") (module_ansi_header ";")] @cursor) @endable @indent
+ (#endwise! "endmodule"))
+([(module_nonansi_header ";" @cursor)
+  (module_ansi_header ";" @cursor)] @endable @indent
+ (#endwise! "endmodule"))
+((ERROR ("module" . [ (simple_identifier) (escaped_identifier) ] . ";" @cursor) @indent) (#endwise! "endmodule"))
+((interface_declaration
+   . [(interface_nonansi_header ";") (interface_ansi_header ";")] @cursor) @endable @indent
+ (#endwise! "endinterface"))
+([(interface_nonansi_header ";" @cursor)
+  (interface_ansi_header ";" @cursor)] @endable @indent
+ (#endwise! "endinterface"))
+((ERROR ("interface" . [ (simple_identifier) (escaped_identifier) ] . ";" @cursor) @indent) (#endwise! "endinterface"))
+((class_declaration . "virtual"? . "class" ";" @cursor) @endable @indent
+ (#endwise! "endclass"))
+((ERROR ("class" . [ (simple_identifier) (escaped_identifier) ]? . ";" @cursor) @indent (#endwise! "endclass")))
+((interface_class_declaration . "interface" . "class" ";" @cursor) @endable @indent
+ (#endwise! "endclass"))
+((ERROR ("interface" . "class" . [ (simple_identifier) (escaped_identifier) ] . ";" @cursor) @indent (#endwise! "endclass")))
+((package_declaration . "package" ";" @cursor) @endable @indent
+ (#endwise! "endpackage"))
+((ERROR ("package" . [ (simple_identifier) (escaped_identifier) ] . ";" @cursor) @indent) (#endwise! "endpackage"))
+((class_constructor_declaration . "function" ";" @cursor) @endable @indent
+ (#endwise! "endfunction: new"))
+((ERROR 
+   [("function" . "new" . ";" @cursor)
+    ("function" . "new" . "(" . (class_constructor_arg_list)? . ")" . ";" @cursor)]
+   @indent) (#endwise! "endfunction: new"))
+((function_body_declaration . (_) ";" @cursor) @endable @indent
+ (#endwise! "endfunction"))
+((ERROR 
+   [("function" . [ (simple_identifier) (escaped_identifier) ] . ";" @cursor)
+    ("function" . [ (simple_identifier) (escaped_identifier) ] . "(" . (tf_port_list)? . ")" . ";" @cursor)]
+   @indent) (#endwise! "endfunction"))
+((task_body_declaration . (_) ";" @cursor) @endable @indent
+ (#endwise! "endtask"))
+((ERROR 
+   [("task" . [ (simple_identifier) (escaped_identifier) ] . ";" @cursor)
+    ("task" . [ (simple_identifier) (escaped_identifier) ] . "(" . (tf_port_list)? . ")" . ";" @cursor)]
+   @indent) (#endwise! "endtask"))
+((property_declaration . "property" ";" @cursor) @endable @indent
+ (#endwise! "endproperty"))
+((ERROR 
+   [("property" . [ (simple_identifier) (escaped_identifier) ] . ";" @cursor)
+    ("property" . [ (simple_identifier) (escaped_identifier) ] . "(" . (property_port_list)? . ")" . ";" @cursor)]
+   @indent) (#endwise! "endproperty"))
+((generate_region . "generate" @cursor) @endable @indent
+ (#endwise! "endgenerate"))
+((ERROR ("generate" @cursor) @indent) (#endwise! "endgenerate"))
+((case_generate_construct . "case" "(" (_) ")" @cursor) @endable @indent
+ (#endwise! "endcase"))
+([(generate_block . (_) . "begin" @cursor)
+  (generate_block . (_) . "begin" ":" name: (_) @cursor)] @endable @indent
+ (#endwise! "end"))
+([(seq_block . "begin" @cursor) 
+  (seq_block . "begin" ":" (_) @cursor)] @endable @indent
+ (#endwise! "end"))
+((ERROR ("begin" @cursor) @indent) (#endwise! "end"))
+((par_block
+   . [ "fork" ("fork" ":" (_)) ] @cursor
+ ) @endable @indent
+ (#endwise! "join"))
+((ERROR ("fork" @cursor) @indent) (#endwise! "join"))
+([(case_statement . [ "case" (case_keyword) ] "(" (_) ")" "inside" @cursor)
+  (case_statement . [ "case" (case_keyword) ] "(" (_) ")" @cursor)] @endable @indent
+ (#endwise! "endcase"))
+((ERROR
+   [("case" . "(" . (_) . ")" . "inside" @cursor)
+    ("case" . "(" . (_) . ")" @cursor)]
+   @indent) (#endwise! "endcase"))

--- a/tests/endwise/verilog.rb
+++ b/tests/endwise/verilog.rb
@@ -1,0 +1,259 @@
+config({
+  extension: "v",
+  overrides: <<~INIT_LUA
+vim.opt.expandtab = true
+vim.opt.shiftwidth = 2
+INIT_LUA
+})
+
+test "verilog, module declaration non-ansi", <<~END
+-module foo;█
++module foo;
++  
++endmodule
+END
+
+test "verilog, module declaration ansi", <<~END
+-module foo(input clk, input reset);█
++module foo(input clk, input reset);
++  
++endmodule
+END
+
+test "verilog, interface declaration non-ansi", <<~END
+-interface foo;█
++interface foo;
++  
++endinterface
+END
+
+test "verilog, interface declaration ansi", <<~END
+-interface foo(input clk, input reset);█
++interface foo(input clk, input reset);
++  
++endinterface
+END
+
+test "verilog, class declaration", <<~END
+-class foo;█
++class foo;
++  
++endclass
+END
+
+test "verilog, virtual class declaration", <<~END
+-virtual class foo;█
++virtual class foo;
++  
++endclass
+END
+
+test "verilog, interface class declaration", <<~END
+-interface class foo;█
++interface class foo;
++  
++endclass
+END
+
+test "verilog, package declaration", <<~END
+-package foo;█
++package foo;
++  
++endpackage
+END
+
+test "verilog, class constructor declaration", <<~END
+-function new;█
++function new;
++  
++endfunction: new
+END
+
+test "verilog, class constructor with arguments", <<~END
+-function new(int a, int b);█
++function new(int a, int b);
++  
++endfunction: new
+END
+
+test "verilog, function declaration", <<~END
+-function foo;█
++function foo;
++  
++endfunction
+END
+
+test "verilog, function with arguments", <<~END
+-function foo(input a, output b);█
++function foo(input a, output b);
++  
++endfunction
+END
+
+test "verilog, task declaration", <<~END
+-task foo;█
++task foo;
++  
++endtask
+END
+
+test "verilog, task with arguments", <<~END
+-task foo(input a, output b);█
++task foo(input a, output b);
++  
++endtask
+END
+
+test "verilog, property declaration", <<~END
+-property foo;█
++property foo;
++  
++endproperty
+END
+
+test "verilog, property with arguments", <<~END
+-property foo(input a, logic b);█
++property foo(input a, logic b);
++  
++endproperty
+END
+
+test "verilog, generate region", <<~END
+-generate█
++generate
++  
++endgenerate
+END
+
+test "verilog, case generate construct", <<~END
+-case(select)█
++case(select)
++  
++endcase
+END
+
+test "verilog, generate block", <<~END
+-if (condition) begin█
++if (condition) begin
++  
++end
+END
+
+test "verilog, generate block with name", <<~END
+-if (condition) begin: my_block█
++if (condition) begin: my_block
++  
++end
+END
+
+test "verilog, sequential block", <<~END
+-begin█
++begin
++  
++end
+END
+
+test "verilog, sequential block with name", <<~END
+-begin: my_block█
++begin: my_block
++  
++end
+END
+
+test "verilog, parallel block", <<~END
+-fork█
++fork
++  
++join
+END
+
+test "verilog, parallel block with name", <<~END
+-fork: my_fork█
++fork: my_fork
++  
++join
+END
+
+test "verilog, case statement", <<~END
+-case(expr)█
++case(expr)
++  
++endcase
+END
+
+test "verilog, case inside statement", <<~END
+-case(expr) inside█
++case(expr) inside
++  
++endcase
+END
+
+test "verilog, nested module", <<~END
+-module outer;
+-  module inner;█
+-endmodule
++module outer;
++  module inner;
++    
++  endmodule
++endmodule
+END
+
+test "verilog, nested function", <<~END
+-module foo;
+-  function bar;█
+-endmodule
++module foo;
++  function bar;
++    
++  endfunction
++endmodule
+END
+
+test "verilog, nested task", <<~END
+-module foo;
+-  task proc;█
+-endmodule
++module foo;
++  task proc;
++    
++  endtask
++endmodule
+END
+
+test "verilog, nested case statements", <<~END
+-module foo;
+-  initial begin
+-    case(x)█
+-  end
+-endmodule
++module foo;
++  initial begin
++    case(x)
++      
++    endcase
++  end
++endmodule
+END
+
+test "verilog, begin in task", <<~END
+-task foo;
+-  begin█
+-endtask
++task foo;
++  begin
++    
++  end
++endtask
+END
+
+test "verilog, fork in function", <<~END
+-function foo;
+-  fork█
+-endfunction
++function foo;
++  fork
++    
++  join
++endfunction
+END


### PR DESCRIPTION
Unfortunately, I was unable to run tests using `ruby ./tests/runner.rb verilog`.

Although it doesn't cover all cases due to [Verilog](https://en.wikipedia.org/wiki/Verilog)'s complex [grammar](https://github.com/gmlarumbe/tree-sitter-systemverilog/blob/master/grammar.js), I avoided using predicates in endwise.scm.

Please let me know if there are any mistakes in the tests or queries.