### PR TITLE
Prevent `nil` error in `is_supported()`

### DIFF
--- a/lua/nvim-treesitter-endwise.lua
+++ b/lua/nvim-treesitter-endwise.lua
@@ -54,6 +54,9 @@ function M.is_supported(lang)
 
         if queries.has_query_files(nested_lang, 'injections') then
             local query = queries.get_query(nested_lang, 'injections')
+            if not query then
+                return false
+            end
             for _, capture in ipairs(query.info.captures) do
                 if capture == 'language' or has_nested_endwise_language(capture) then
                     return true


### PR DESCRIPTION
Thanks a lot for making this plugin!

## Summary

This PR prevents a potential `nil` error by adding an extra check.

After a search within this repo, I have discovered the following prior art that can further justify this change:

https://github.com/RRethy/nvim-treesitter-endwise/blob/8b6436303dda9ce6ed4b3733fd15703eb3589c36/lua/nvim-treesitter/endwise.lua#L131-L134

... it could indicate a problem in the type annotation of the `get_query()` function, because the return value can actually be `nil`:

```lua
function M.get_query(lang: string, query_name: string) -> Query
```

I have tested the patch locally and I'm sure it is working properly and has fixed the issue.

## Background

When using this plugin with https://github.com/moonbit-community/moonbit.nvim, unfortunately, the following error will occur:

```console
Error detected while processing FileType Autocommands for "moonbit"..FileType Autocommands for "*":      
                                                                                                         
Error executing lua callback: .../nvim-treesitter-endwise/lua/nvim-treesitter-endwise.lua:57: attempt to index local 'query' (a nil value)                                                                        
stack traceback:                                                                                         
        .../nvim-treesitter-endwise/lua/nvim-treesitter-endwise.lua:57: in function 'is_supported'       
        .../nvim-treesitter-endwise/lua/nvim-treesitter-endwise.lua:13: in function <.../nvim-treesitter-endwise/lua/nvim-treesitter-endwise.lua:9>                                                               
        [C]: in function 'nvim_exec_autocmds'                                                            
        ...hare/nvim/lazy/lazy.nvim/lua/lazy/core/handler/event.lua:161: in function <...hare/nvim/lazy/lazy.nvim/lua/lazy/core/handler/event.lua:160>                                                            
        [C]: in function 'xpcall'                                                                        
        .../.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/util.lua:135: in function 'try'               
        ...hare/nvim/lazy/lazy.nvim/lua/lazy/core/handler/event.lua:160: in function 'trigger'           
        ...hare/nvim/lazy/lazy.nvim/lua/lazy/core/handler/event.lua:89: in function <...hare/nvim/lazy/lazy.nvim/lua/lazy/core/handler/event.lua:72>
...
```

It is quite possible that MoonBit's [injections.scm](https://github.com/moonbit-community/moonbit.nvim/blob/fb2e5e8f44803e9a0e2547c6abdcf6e4f1fec9b0/queries/moonbit/injections.scm) is problematic as well, but I wouldn't expect such an error to occur from a predicate function such as `is_supported()`, so I have made this patch, imagining the same thing could happen to other new languages with out-of-tree treesitter support.

