### PR TITLE
Migrate from nvim-treesitter module APIs to stable Neovim treesitter APIs

### DIFF
--- a/lua/nvim-treesitter-endwise.lua
+++ b/lua/nvim-treesitter-endwise.lua
@@ -1,6 +1,3 @@
-local queries = require("nvim-treesitter.query")
-local parsers = require('nvim-treesitter.parsers')
-
 local M = {}
 
 function M.init()
@@ -41,23 +38,24 @@ function M.is_supported(lang)
             return false
         end
 
-        if not parsers.has_parser(nested_lang) then
+        local parser, _ = vim.treesitter.get_parser(0, nested_lang, { error = false })
+        if not parser then
             return false
         end
-        if queries.has_query_files(nested_lang, 'endwise') then
+
+        local query = vim.treesitter.query.get(nested_lang, 'endwise')
+        if query ~= nil then
             return true
         end
+
         if seen[nested_lang] then
             return false
         end
         seen[nested_lang] = true
 
-        if queries.has_query_files(nested_lang, 'injections') then
-            local query = queries.get_query(nested_lang, 'injections')
-            if not query then
-                return false
-            end
-            for _, capture in ipairs(query.info.captures) do
+        local injections_query = vim.treesitter.query.get(nested_lang, 'injections')
+        if injections_query ~= nil then
+            for _, capture in ipairs(injections_query.info.captures) do
                 if capture == 'language' or has_nested_endwise_language(capture) then
                     return true
                 end

--- a/tests/init.lua
+++ b/tests/init.lua
@@ -1,15 +1,5 @@
 vim.opt.runtimepath:append('.')
-vim.opt.runtimepath:append('../nvim-treesitter')
-vim.opt.runtimepath:append('../playground')
 vim.opt.showmode = false
-require('nvim-treesitter.configs').setup {
-    playground = {
-        enable = true,
-    },
-    endwise = {
-        enable = true,
-    },
-}
 
 local function feedkeys(input)
     local keys = vim.api.nvim_replace_termcodes(input, true, false, true)


### PR DESCRIPTION
## Summary

Close https://github.com/RRethy/nvim-treesitter-endwise/issues/50
Close https://github.com/RRethy/nvim-treesitter-endwise/issues/27

This PR migrates the codebase from nvim-treesitter's internal module APIs to Neovim's stable treesitter APIs, improving compatibility and reducing dependencies on internal nvim-treesitter modules.

## Changes

- Replace `nvim-treesitter.parsers` with native `vim.treesitter.get_parser()` API
- Replace `nvim-treesitter.query` with native `vim.treesitter.query.get()` API  
- Replace `nvim-treesitter.ts_utils` with native `vim.treesitter.get_node()` API
- Update parser existence checks to use error handling approach
- Simplify test initialization by removing unnecessary nvim-treesitter configuration

## Benefits

- Better forward compatibility with future Neovim versions
- Reduced coupling to nvim-treesitter internals
- Uses officially supported stable APIs
- Cleaner, more maintainable code

## Testing

Tests are broken.