### PR TITLE
Ignore errors in unloaded buffers

### DIFF
--- a/lua/nvim-treesitter-endwise.lua
+++ b/lua/nvim-treesitter-endwise.lua
@@ -38,8 +38,8 @@ function M.is_supported(lang)
             return false
         end
 
-        local parser, _ = vim.treesitter.get_parser(0, nested_lang, { error = false })
-        if not parser then
+        local ok, parser = pcall(vim.treesitter.get_parser, 0, nested_lang, { error = false })
+        if not ok or not parser then
             return false
         end
 


### PR DESCRIPTION
### Description

Calling `vim.treesitter.get_parser()` with an unloaded buffer raises an error, even if `{ error = false }` is passed.

Ignore this error by wrapping the call in `pcall`.

### Context

I ran into this error after the refactoring in https://github.com/RRethy/nvim-treesitter-endwise/commit/02a9e4e096e087bc417059e303e30af7f5f07971, now toggling a comment via `mini.comment` results in this error:

```
E5108: Error executing lua ...x-x86_64/share/nvim/runtime/lua/vim/filetype/options.lua:82: FileType Autocommands for "*": Vim(append):Error executing lua callback: ...m-linux
-x86_64/share/nvim/runtime/lua/vim/treesitter.lua:104: Buffer 4 must be loaded to create parser
stack traceback:
        [C]: in function 'error'
        ...m-linux-x86_64/share/nvim/runtime/lua/vim/treesitter.lua:104: in function 'get_parser'
        .../nvim-treesitter-endwise/lua/nvim-treesitter-endwise.lua:41: in function 'is_supported'
        .../nvim-treesitter-endwise/lua/nvim-treesitter-endwise.lua:10: in function <.../nvim-treesitter-endwise/lua/nvim-treesitter-endwise.lua:6>
        [C]: in function 'nvim_get_option_value'
        ...x-x86_64/share/nvim/runtime/lua/vim/filetype/options.lua:82: in function 'get_option'
        ...ck/dotfiles/packages/lazy/mini.nvim/lua/mini/comment.lua:392: in function 'traverse'
        ...ck/dotfiles/packages/lazy/mini.nvim/lua/mini/comment.lua:402: in function 'get_commentstring'
        ...ck/dotfiles/packages/lazy/mini.nvim/lua/mini/comment.lua:465: in function 'get_comment_parts'
        ...ck/dotfiles/packages/lazy/mini.nvim/lua/mini/comment.lua:249: in function 'toggle_lines'
        ...ck/dotfiles/packages/lazy/mini.nvim/lua/mini/comment.lua:207: in function <...ck/dotfiles/packages/lazy/mini.nvim/lua/mini/comment.lua:177>
stack traceback:
        [C]: in function 'nvim_get_option_value'
        ...x-x86_64/share/nvim/runtime/lua/vim/filetype/options.lua:82: in function 'get_option'
        ...ck/dotfiles/packages/lazy/mini.nvim/lua/mini/comment.lua:392: in function 'traverse'
        ...ck/dotfiles/packages/lazy/mini.nvim/lua/mini/comment.lua:402: in function 'get_commentstring'
        ...ck/dotfiles/packages/lazy/mini.nvim/lua/mini/comment.lua:465: in function 'get_comment_parts'
        ...ck/dotfiles/packages/lazy/mini.nvim/lua/mini/comment.lua:249: in function 'toggle_lines'
        ...ck/dotfiles/packages/lazy/mini.nvim/lua/mini/comment.lua:207: in function <...ck/dotfiles/packages/lazy/mini.nvim/lua/mini/comment.lua:177>
```

I'm not sure what is going on exactly, but it looks like `Buffer 4` is a temporary buffer created by `mini.comment` (or some other plugin).

I figured I'll add a `pcall` since `mini.comment` does the same: https://github.com/echasnovski/mini.nvim/blob/8f2ea1e69546d2606b97cb1c0e9458a1a0d2e73f/lua/mini/comment.lua#L366-L367

Let me know if you prefer an explicit `nvim_buf_is_loaded()` check, as in https://github.com/neovim/neovim/blob/c12701d4e1404a67fef6da01a8a9d7e2d48d78d6/runtime/lua/vim/treesitter.lua#L103