### PR TITLE
Fix `let` queries in julia

### DIFF
--- a/queries/julia/endwise.scm
+++ b/queries/julia/endwise.scm
@@ -44,12 +44,12 @@
  (#endwise! "end"))
 
 ((let_statement "let" @cursor
-  [(identifier) (let_binding)]? @cursor
+  [(identifier) (assignment)]? @cursor
  ) @indent @endable
  (#endwise! "end"))
 
 ((ERROR "let" @cursor @indent
-  [(identifier) (let_binding) (assignment)]? @cursor
+  [(identifier) (assignment)]? @cursor
  )
  (#endwise! "end"))
 


### PR DESCRIPTION
This fixes `let` bindings in julia.

I couldn't run the tests for this as they seem to be broken on `master`. They do not pass not only for julia but also for other languages

