### PR TITLE
fix: Don't try getting node when row/col are negative

### DIFF
--- a/lua/nvim-treesitter/endwise.lua
+++ b/lua/nvim-treesitter/endwise.lua
@@ -120,6 +120,9 @@ local function endwise(bufnr)
         return
     end
 
+    if row < 0 or col < 0 then
+        return
+    end
 
     local node = vim.treesitter.get_node({
         bufnr = bufnr,


### PR DESCRIPTION
As of NeoVim 0.11 `get_node` hard enforces row and col to be non-negative (via assert), that causes endwise fail in those cases:

```
Error executing vim.schedule lua callback: /usr/share/nvim/runtime/lua/vim/treesitter.lua:384: Invalid position: row and col must be non-negative                                                                                
stack traceback:                                                                                                                                                                                                                 
        [C]: in function 'assert'                                                                                                                                                                                                
        /usr/share/nvim/runtime/lua/vim/treesitter.lua:384: in function 'get_node'                                                                                                                                               
        .../nvim-treesitter-endwise/lua/nvim-treesitter/endwise.lua:124: in function 'endwise'                                                                                                                                   
        .../nvim-treesitter-endwise/lua/nvim-treesitter/endwise.lua:216: in function ''                                                                                                                                          
        vim/_editor.lua: in function <vim/_editor.lua:0>  
```

This patch makes it compatible with previous and current version of NeoVim by exiting early when it's clear that get_node will return nil (on NeoVim 0.10) or fail (on NeoVim 0.11).