### PR TITLE
Nvim 0 11 compat

### DIFF
--- a/lua/nvim-treesitter/endwise.lua
+++ b/lua/nvim-treesitter/endwise.lua
@@ -120,6 +120,9 @@ local function endwise(bufnr)
         return
     end
 
+    if row < 0 or col < 0 then
+        return
+    end
 
     local node = vim.treesitter.get_node({
         bufnr = bufnr,

--- a/lua/nvim-treesitter/endwise.lua
+++ b/lua/nvim-treesitter/endwise.lua
@@ -111,16 +111,13 @@ local function endwise(bufnr)
 
     -- Search up the first the closest non-whitespace text before the cursor
     local row, col = unpack(vim.fn.searchpos('\\S', 'nbW'))
+    if row == 0 or col == 0 then return end
     row = row - 1
     col = col - 1
 
     local lang_tree = parser:language_for_range({ row, col, row, col })
     lang = lang_tree:lang()
     if not lang then
-        return
-    end
-
-    if row < 0 or col < 0 then
         return
     end
 

--- a/tests/endwise/regressions.rb
+++ b/tests/endwise/regressions.rb
@@ -1,0 +1,13 @@
+config({
+  extension: "lua",
+  overrides: <<~INIT_LUA
+vim.opt.expandtab = true
+vim.opt.shiftwidth = 2
+INIT_LUA
+})
+
+test "regression: <CR> at row 1 col 1 does not error", <<~END
+-█
++
++
+END


### PR DESCRIPTION
Merge RRethy/nvim-treesitter-endwise#57 to resolve RRethy/nvim-treesitter-endwise#54.

Fixes a crash caused by invalid cursor positions being passed to vim.treesitter.get_node(). As of Neovim 0.11, `get_node()` asserts that row and column values must be non-negative, causing a hard failure when negative positions are passed in.

This change adds an explicit early guard for the searchpos() “not found” case, before the values are converted to 0-base. This ensures that invalid positions are never created and keeps behaviour compatible with both earlier and current Neovim releases.

The PR also includes a regression test covering <CR> at row 1, col 1 in an empty file to ensure this path no longer raises an error.